### PR TITLE
Add support for Cardano testnet

### DIFF
--- a/src/Validation/ADA.php
+++ b/src/Validation/ADA.php
@@ -51,7 +51,8 @@ class ADA extends Base58Validation
         if (!$valid) {
             // maybe it's a bech32 address
             try {
-                $valid = is_array($decoded = Bech32Decoder::decodeRaw($address)) && 'addr' === $decoded[0];
+                $prefixes = ['addr', 'addr_test'];
+                $valid = is_array($decoded = Bech32Decoder::decodeRaw($address)) && in_array($decoded[0], $prefixes);
             } catch (Bech32Exception $exception) {}
         }
 

--- a/tests/Validation/ADATest.php
+++ b/tests/Validation/ADATest.php
@@ -19,6 +19,7 @@ class ADATest extends BaseValidationTestCase
         return [
             ['addr1v8v3auqmw0eszza3ww29ea2pwftuqrqqyu26zvzjq9dt2ncydzvs5', true],
             ['DdzFFzCqrht2KYLcX8Vu53urCG52NxpgrGQvP9Mcp15Q8BkB9df9GndFDBRjoWTPuNkLW3yeQiFVet1KA7mraEkJ84AK2RwcEh3khs12', true],
+            ['addr_test1qp3a5h2v77amavax2qh9z47jxp0hwr22e2285l5d5akehhs8a9exu0g55mhg8csra7q7686wdmrpcyhjc7gjj4m0ryesevy4gl', true],
             ['qrll76p3mfl69p07vyvqzwy3crqy8myvrytgv8v7f7', false],
             ['pruptvpkmxamee0f72sq40gm70wfr624zq0yyxtycm', false],
             ['LbTjMGN7gELw4KbeyQf6cTCq859hD18guE', false],


### PR DESCRIPTION
Testnet addresses start with `addr_test` but they still are valid.
https://forum.cardano.org/t/send-ada-using-cardano-cli-to-daedalus-invalid-address/42289/6