### PR TITLE
fix: driver config construction from cache

### DIFF
--- a/src/DriverConfig.php
+++ b/src/DriverConfig.php
@@ -45,4 +45,13 @@ readonly class DriverConfig
             ?: $this->mainnet
                 ?: [];
     }
+
+    public static function __set_state(array $state): DriverConfig
+    {
+        return new self(
+            $state['driver'],
+            $state['mainnet'],
+            $state['testnet']
+        );
+    }
 }


### PR DESCRIPTION
Fixed `Call to undefined method Merkeleon\PhpCryptocurrencyAddressValidation\Drive  
  rConfig::__set_state()` while trying to build a config cache having the library config in the app directory slightly changed (`artisan config:cache`)